### PR TITLE
Multiple file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "millet-core",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -240,6 +241,15 @@ name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+
+[[package]]
+name = "toml"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/ls/Cargo.toml
+++ b/crates/ls/Cargo.toml
@@ -11,3 +11,4 @@ lsp-types = "0.74"
 millet-core = { path = "../core" }
 serde = "1.0"
 serde_json = "1.0"
+toml = "0.5"

--- a/crates/ls/src/config.rs
+++ b/crates/ls/src/config.rs
@@ -1,0 +1,49 @@
+use lsp_types::Url;
+use serde::Deserialize;
+use std::io::{self, Read};
+
+#[derive(Deserialize)]
+struct ConfigDe {
+  files: Vec<String>,
+}
+
+#[derive(Default, Debug)]
+pub struct Config {
+  files: Vec<Url>,
+}
+
+// TODO: maybe make into array of possible config locations?
+pub const CONFIG_FILE: &'static str = "millet.toml";
+
+impl Config {
+  pub fn new(root: &Url) -> io::Result<Self> {
+    Ok(if root.scheme() == "file" {
+      let root =
+        Url::parse(&(root.clone().into_string() + "/")).map_err(|_| io::ErrorKind::InvalidData)?;
+      match root.to_file_path() {
+        Ok(mut path) => {
+          path.push(CONFIG_FILE);
+          let mut config_file = std::fs::File::open(path)?;
+          let mut buf = String::new();
+          config_file.read_to_string(&mut buf)?;
+          let config: ConfigDe = toml::from_str(&buf)?;
+          Config {
+            files: config
+              .files
+              .into_iter()
+              .map(|f| root.join(&f))
+              .collect::<Result<_, _>>()
+              .map_err(|_| io::ErrorKind::InvalidData)?,
+          }
+        }
+        Err(()) => Default::default(),
+      }
+    } else {
+      Default::default()
+    })
+  }
+
+  pub fn get_files(&self) -> &[Url] {
+    &self.files
+  }
+}

--- a/crates/ls/src/main.rs
+++ b/crates/ls/src/main.rs
@@ -1,6 +1,7 @@
 //! A language server for Standard ML.
 
 mod comm;
+mod config;
 mod headers;
 mod io;
 mod state;

--- a/crates/ls/src/main.rs
+++ b/crates/ls/src/main.rs
@@ -1,10 +1,10 @@
 //! A language server for Standard ML.
 
 mod comm;
-mod config;
 mod headers;
 mod io;
 mod state;
+mod workspace;
 
 fn main() {
   let (s_inc, r_inc) = crossbeam_channel::unbounded();

--- a/crates/ls/src/state.rs
+++ b/crates/ls/src/state.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::io::{self, Read};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::comm::{
   IncomingNotification, IncomingRequestParams, Outgoing, OutgoingNotification, Request, Response,

--- a/crates/ls/src/workspace.rs
+++ b/crates/ls/src/workspace.rs
@@ -3,31 +3,33 @@ use serde::Deserialize;
 use std::io::{self, Read};
 
 #[derive(Deserialize)]
-struct ConfigDe {
+struct WorkspaceFile {
   files: Vec<String>,
 }
 
 #[derive(Default, Debug)]
-pub struct Config {
+pub struct ProjectWorkspace {
   files: Vec<Url>,
 }
 
-// TODO: maybe make into array of possible config locations?
-pub const CONFIG_FILE: &'static str = "millet.toml";
+pub const WORKSPACE_FILE: &'static str = "millet.toml";
 
-impl Config {
+impl ProjectWorkspace {
   pub fn new(root: &Url) -> io::Result<Self> {
     Ok(if root.scheme() == "file" {
+      // Adding a / is a bit of an ugly hack here so the join for the files specified puts them in
+      // the root directory. Without it the join would replace the root directory name with the
+      // filename(s).
       let root =
         Url::parse(&(root.clone().into_string() + "/")).map_err(|_| io::ErrorKind::InvalidData)?;
       match root.to_file_path() {
         Ok(mut path) => {
-          path.push(CONFIG_FILE);
+          path.push(WORKSPACE_FILE);
           let mut config_file = std::fs::File::open(path)?;
           let mut buf = String::new();
           config_file.read_to_string(&mut buf)?;
-          let config: ConfigDe = toml::from_str(&buf)?;
-          Config {
+          let config: WorkspaceFile = toml::from_str(&buf)?;
+          ProjectWorkspace {
             files: config
               .files
               .into_iter()


### PR DESCRIPTION
This PR would provide initial support for multiple files (detailed in a `millet.toml` file in the workspace root).

Some parts are probably less than ideal:
  - If there are issues with the configuration file this isn't obviously communicated
  - Currently recomputes lexing/parsing/statics for _all_ files on change instead of just files that depend on the one modified
  - Probably more stuff I'm forgetting