### PR TITLE
Publish diagnostics on DidChangeTextDocument notifications

### DIFF
--- a/crates/lang-srv/src/state.rs
+++ b/crates/lang-srv/src/state.rs
@@ -248,6 +248,12 @@ impl State {
       }
       self.publish_diagnostics();
     })?;
+    n = try_notification::<lsp_types::notification::DidChangeTextDocument, _>(n, |_| {
+      if self.root.is_none() {
+        return;
+      }
+      self.publish_diagnostics();
+    })?;
     n = try_notification::<lsp_types::notification::DidOpenTextDocument, _>(n, |params| {
       if self.root.is_some() {
         return;


### PR DESCRIPTION
This PR makes the language server publish diagnostics when it receives a [`DidChangeTextDocument`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange) notification.

Millet already publishes diagnostics on [`DidChangeWatchedFiles`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles) notifications, but client-side support for `workspace/didChangeWatchedFiles` is optional (contrary to `textDocument/didChange`), and some LSP clients such as [`acme-lsp`](https://github.com/fhs/acme-lsp) may not support it ([yet](https://github.com/fhs/acme-lsp/issues/6)).