### PR TITLE
Added basic support for ML-Lex and ML-Yacc files to CM file parser

### DIFF
--- a/crates/cm-syntax/src/lower.rs
+++ b/crates/cm-syntax/src/lower.rs
@@ -16,6 +16,8 @@ pub(crate) fn get(root: ParseRoot) -> Result<CmFile> {
     let kind = match cls {
       Some(class) => match class.val {
         Class::Sml(k) => PathKind::Sml(k),
+        Class::MlLex => PathKind::MlLex,
+        Class::MlYacc => PathKind::MlYacc,
         Class::Cm => PathKind::Cm,
         Class::Other(s) => {
           return Err(Error::new(ErrorKind::UnsupportedClass(path, s), class.range))

--- a/crates/cm-syntax/src/types.rs
+++ b/crates/cm-syntax/src/types.rs
@@ -122,6 +122,10 @@ pub enum CmFileKind {
 pub enum PathKind {
   /// SML files.
   Sml(sml_file::Kind),
+  /// ML-Lex files.
+  MlLex,
+  /// ML-Yacc files.
+  MlYacc,
   /// CM files.
   Cm,
 }
@@ -221,6 +225,10 @@ impl Member {
 pub enum Class {
   /// SML files.
   Sml(sml_file::Kind),
+  /// ML-Lex files.
+  MlLex,
+  /// ML-Yacc files.
+  MlYacc,
   /// CM files.
   Cm,
   /// Some other class.
@@ -230,8 +238,15 @@ pub enum Class {
 impl Class {
   fn from_path(path: &Path) -> Option<Self> {
     let ext = path.extension()?.to_str()?;
-    let ret = if ext == "cm" { Self::Cm } else { Self::Sml(ext.parse().ok()?) };
-    Some(ret)
+    match ext.parse::<sml_file::Kind>() {
+      Ok(kind) => Some(Self::Sml(kind)),
+      Err(_) => match ext {
+        "cm" => Some(Self::Cm),
+        "y" | "grm" => Some(Self::MlYacc),
+        "l" | "lex" => Some(Self::MlLex),
+        _ => None,
+      },
+    }
   }
 }
 
@@ -252,6 +267,8 @@ impl fmt::Display for Class {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Class::Sml(_) => f.write_str("sml"),
+      Class::MlLex => f.write_str("lex"),
+      Class::MlYacc => f.write_str("grm"),
       Class::Cm => f.write_str("cm"),
       Class::Other(s) => f.write_str(s),
     }

--- a/crates/tests/src/input/cm/syntax.rs
+++ b/crates/tests/src/input/cm/syntax.rs
@@ -135,6 +135,70 @@ is
 }
 
 #[test]
+fn ml_lex_file() {
+  check(
+    r"
+Library
+  functor TigerLexerFun
+is
+  lexer.lex
+",
+    vec![mk_name(Namespace::Functor, "TigerLexerFun")],
+    &[("lexer.lex", PathKind::MlLex)],
+  );
+}
+
+#[test]
+fn ml_lex_l_file() {
+  check(
+    r"
+Library
+  functor TigerLexerFun
+is
+  lexer.l
+",
+    vec![mk_name(Namespace::Functor, "TigerLexerFun")],
+    &[("lexer.l", PathKind::MlLex)],
+  );
+}
+
+#[test]
+fn ml_yacc_file() {
+  check(
+    r"
+Library
+  functor TigerLrValsFun
+  signature Tiger_TOKENS
+is
+  parser.grm
+",
+    vec![
+      mk_name(Namespace::Functor, "TigerLrValsFun"),
+      mk_name(Namespace::Signature, "Tiger_TOKENS"),
+    ],
+    &[("parser.grm", PathKind::MlYacc)],
+  );
+}
+
+#[test]
+fn ml_yacc_y_file() {
+  check(
+    r"
+Library
+  functor TigerLrValsFun
+  signature Tiger_TOKENS
+is
+  parser.y
+",
+    vec![
+      mk_name(Namespace::Functor, "TigerLrValsFun"),
+      mk_name(Namespace::Signature, "Tiger_TOKENS"),
+    ],
+    &[("parser.y", PathKind::MlYacc)],
+  );
+}
+
+#[test]
 fn unknown_class() {
   let e =
     cm_syntax::get(r"Group is foo.sml : succ-ml", &slash_var_path::Env::default()).unwrap_err();


### PR DESCRIPTION
## Description

The parser for CM files has been extended to handle ML-Lex and ML-Yacc specification files and add their generated files to the library sources.

## Motivation

ML-Lex and ML-Yacc are SML/NJ's standard lexer and parser generators, respectively, and so have special integration with the CM build system. For source files with the extension ".l" or ".lex", CM automatically runs ML-Lex, which generates a file with the same filename as the ".lex" file with an additional ".sml" extension at the end. For files with ".y" or ".grm" extensions, CM runs ML-Yacc, generating both a ".sig" and ".sml" file in a similar way. All of the generated files are then treated as if they were explicitly listed in the .cm file and regenerated as needed.

Before this change, Millet showed an error ("unknown class") in CM files containing filenames with these extensions. Since the generated files were not being added to Millet's list of source files, completion and other analysis wasn't being done for these files. This limited my ability to use Millet with ML-Yacc and ML-Lex.

## Tests

I have added tests to show that Millet can now parse CM files containing filenames with these extensions. I was not able to find existing tests that verify what actually ends up being added to Millet's sources list after parsing so I did not add any to verify that the generated files are added properly, but I may have missed them.