### PR TITLE
Add failing test case for exhaustivity checking

### DIFF
--- a/crates/tests/src/matching.rs
+++ b/crates/tests/src/matching.rs
@@ -546,3 +546,17 @@ fun parse xs =
 ",
   );
 }
+
+#[test]
+fn non_exhaustive_fail() {
+  check(
+    r#"
+datatype abc = A of {z: {s: int, t: int}, y: int} | B | C
+val _ =
+    case B of
+(** ^^^^^^^^^ non-exhaustive case: missing `C` *)
+    A {z = {s, t}, y} => 0
+  | B => 1
+"#,
+  );
+}


### PR DESCRIPTION
## Description

I added a failing test case. Millet does not generate any errors for the test case, but I think it should. This PR doesn't fix the bug. I only dug far enough to see that the `pattern_match::check` call returns a `CheckError`.
<!-- Describe what changed. -->

## Motivation

To expose what appears to be a bug.
<!-- Explain why you made this change. -->

## Tests

I added a failing test case demonstrating the bug.
<!-- Explain how this change was tested. -->
