### PR TITLE
Allow enabling withtype in signatures

### DIFF
--- a/crates/config/src/file.rs
+++ b/crates/config/src/file.rs
@@ -198,5 +198,7 @@ pub struct SuccessorMl {
   #[serde(default)]
   pub exp_row_pun: bool,
   #[serde(default)]
+  pub sig_withtype: bool,
+  #[serde(default)]
   pub vector: bool,
 }

--- a/crates/sml-hir-lower/src/dec.rs
+++ b/crates/sml-hir-lower/src/dec.rs
@@ -366,12 +366,15 @@ fn get_spec_one(st: &mut St<'_>, dec: Option<ast::DecOne>) -> Vec<sml_hir::SpecI
       if !st.lang().dec.datatype {
         st.err(dec.syntax(), ErrorKind::Disallowed(Disallowed::Dec("`datatype`")));
       }
-      if let Some(with_type) = dec.with_type() {
-        let e = ErrorKind::Disallowed(Disallowed::SuccMl("`withtype` in specifications"));
-        st.err(with_type.syntax(), e);
+      if !st.lang().successor_ml.sig_withtype {
+        if let Some(with_type) = dec.with_type() {
+          let e = ErrorKind::Disallowed(Disallowed::SuccMl("`withtype` in specifications"));
+          st.err(with_type.syntax(), e);
+        }
       }
-      let binds = dat_binds(st, dec.dat_binds());
-      let dat = sml_hir::Spec::Datatype(binds);
+      let d_binds = dat_binds(st, dec.dat_binds());
+      let t_binds = ty_binds(st, dec.with_type().into_iter().flat_map(|x| x.ty_binds()));
+      let dat = sml_hir::Spec::Datatype(d_binds, t_binds);
       vec![st.spec(dat, ptr)]
     }
     ast::DecOne::DatCopyDec(dec) => {

--- a/crates/sml-hir/src/lib.rs
+++ b/crates/sml-hir/src/lib.rs
@@ -142,7 +142,8 @@ pub enum Spec {
   Val(Vec<TyVar>, Vec<ValDesc>),
   Ty(TyDesc),
   EqTy(TyDesc),
-  Datatype(Vec<DatDesc>),
+  /// The `TyBinds` are from `withtype`, since it's easier to process in statics than lower.
+  Datatype(Vec<DatDesc>, Vec<TyBind>),
   DatatypeCopy(Name, Path),
   Exception(ExDesc),
   Str(StrDesc),

--- a/crates/sml-statics/src/top_dec.rs
+++ b/crates/sml-statics/src/top_dec.rs
@@ -497,9 +497,9 @@ fn get_spec_one(
       get_ty_desc(st, spec.into(), &mut ac.ty_env, ty_descs, Equality::Sometimes);
     }
     // @def(71)
-    sml_hir::Spec::Datatype(dat_descs) => {
+    sml_hir::Spec::Datatype(dat_descs, with_types) => {
       let (ty_env, big_val_env) =
-        dec::get_dat_binds(st, spec.into(), bs.as_cx(), ars, dat_descs, &[]);
+        dec::get_dat_binds(st, spec.into(), bs.as_cx(), ars, dat_descs, with_types);
       for (name, val) in ty_env {
         if let Some(e) = ins_no_dupe(&mut ac.ty_env, name, val, Item::Ty) {
           st.err(spec, e);

--- a/crates/sml-ty-var-scope/src/lib.rs
+++ b/crates/sml-ty-var-scope/src/lib.rs
@@ -148,7 +148,7 @@ fn get_spec_one(st: &mut St, ars: &sml_hir::Arenas, spec: sml_hir::SpecIdx) {
     sml_hir::Spec::Sharing(spec, _, _) => get_spec(st, ars, spec),
     sml_hir::Spec::Ty(_)
     | sml_hir::Spec::EqTy(_)
-    | sml_hir::Spec::Datatype(_)
+    | sml_hir::Spec::Datatype(_, _)
     | sml_hir::Spec::DatatypeCopy(_, _)
     | sml_hir::Spec::Exception(_) => {}
   }

--- a/crates/tests/src/deviations/successor_ml/withtype_spec.rs
+++ b/crates/tests/src/deviations/successor_ml/withtype_spec.rs
@@ -1,9 +1,9 @@
 //! Tests for `withtype` in specifications.
 
-use crate::check::check;
+use crate::check::{check, check_multi, raw};
 
 #[test]
-fn disallow() {
+fn default_disallow() {
   check(
     r"
 signature STREAM =
@@ -14,4 +14,25 @@ signature STREAM =
   end
 ",
   );
+}
+
+#[test]
+fn config_allow() {
+  let config = r"
+version = 1
+language.successor-ml.sig-withtype = true
+";
+  let sml = r"
+signature STREAM =
+  sig
+    datatype 'a u = Nil | Cons of 'a * 'a t
+    withtype 'a t = unit -> 'a u
+  end
+structure Stream : STREAM =
+  struct
+    datatype 'a u = Nil | Cons of 'a * (unit -> 'a u)
+    type 'a t = unit -> 'a u
+  end
+";
+  check_multi(raw::singleton(config, sml));
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog is not an exhaustive list of changes between versions. For that, c
 
 Millet technically follows [SemVer][sem-ver], but the major version is zero, and it probably will be [for a while][zero-ver].
 
+## main
+
+- Support `withtype` in signatures under `language.successor-ml.sig-withtype`.
+
 ## v0.14.8
 
 - Support holes in CM and MLB.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -473,6 +473,19 @@ fun incB {a, b, c} = {a, b = b + 1, c}
 fun incB {a, b, c} = {a = a, b = b + 1, c = c}
 ```
 
+#### `language.successor-ml.sig-withtype`
+
+- Type: `boolean`
+- Default: `false`
+
+```sml
+signature STREAM =
+  sig
+    datatype 'a u = Nil | Cons of 'a * 'a t
+    withtype 'a t = unit -> 'a u
+  end
+```
+
 #### `language.successor-ml.vector`
 
 - Type: `boolean`


### PR DESCRIPTION
## Description

This adds the option `language.successor-ml.sig-withtype` to allow `withtype` in signatures.

## Motivation

Better SuccessorML support.

## Tests

I added a test to the tests crate.
